### PR TITLE
Minor cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,5 @@ install:
   - go get github.com/garyburd/go-oauth/oauth
 
 go:
-  - 1.1
-  - 1.2
-  - 1.3
+  - 1.4.2
   - tip
-

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,24 @@
 # tests without -tabs for go tip
-travis: get .PHONY
-	# Run Tests
-	go test -test.v
 
-test: format .PHONY
-	# Run Tests
+# Run Tests
+travis: get
+	go test -v
+
+# Run Tests
+test: format
 	go test
 
+# Go Get Deps
 get:
-	# Go Get Deps
 	go get github.com/garyburd/go-oauth/oauth
 	go get github.com/jmervine/GoT
 
-docs: format .PHONY
-	# Show Docs
-	@godoc -ex . | sed -e 's/func /\nfunc /g' | less
-	@#                                         ^ add a little spacing for readability
+# Show Docs
+docs: format
+	@godoc -ex . | sed -e 's/func /\nfunc /g' | less # add a little spacing for readability
 
-format: .PHONY
-	# Go Fmt Source
-	@gofmt -w -l $(shell find . -type f -name "*.go")
+# Go Fmt Source
+format:
+	@gofmt -s -w -l $(shell find . -type f -name "*.go")
 
-.PHONY:
+.PHONY: travis test docs format

--- a/examples_test.go
+++ b/examples_test.go
@@ -19,10 +19,6 @@ var (
 	secret = os.Getenv("SECRET")
 )
 
-/****
- * Examples
- *******************************************************************/
-
 func Example() {
 	// Basic Get
 	max := maxcdn.NewMaxCDN(alias, token, secret)
@@ -53,21 +49,17 @@ func Example() {
 	// Logs
 	if logs, err := max.GetLogs(nil); err == nil {
 		for _, line := range logs.Records {
-			fmt.Println("%+v\n", line)
+			fmt.Printf("%+v\n", line)
 		}
 	}
 }
 
-/****
- * MaxCDN Examples
- *******************************************************************/
-
-func ExampleNewMaxCDN() {
+func Example_newMaxCDN() {
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 	fmt.Printf("%#v\n", max)
 }
 
-func ExampleMaxCDN_DoParse() {
+func ExampleMaxCDN_doParse() {
 	// Run mid-level DoParse method.
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 
@@ -81,7 +73,7 @@ func ExampleMaxCDN_DoParse() {
 	fmt.Printf("name: %s\n", data["street1"].(string))
 }
 
-func ExampleMaxCDN_Do() {
+func ExampleMaxCDN_do() {
 	// Run low-level Do method.
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 
@@ -95,7 +87,7 @@ func ExampleMaxCDN_Do() {
 	}
 }
 
-func ExampleMaxCDN_Request() {
+func ExampleMaxCDN_request() {
 	// Run low-level Request method.
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 
@@ -115,7 +107,7 @@ func ExampleMaxCDN_Request() {
 	fmt.Println(string(body))
 }
 
-func ExampleMaxCDN_Get() {
+func ExampleMaxCDN_get() {
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 
 	var data maxcdn.Generic
@@ -128,16 +120,16 @@ func ExampleMaxCDN_Get() {
 	fmt.Printf("name: %s\n", data["street1"].(string))
 }
 
-func ExampleMaxCDN_GetLogs() {
+func ExampleMaxCDN_getLogs() {
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 	if logs, err := max.GetLogs(nil); err == nil {
 		for _, line := range logs.Records {
-			fmt.Println("%+v\n", line)
+			fmt.Printf("%+v\n", line)
 		}
 	}
 }
 
-func ExampleMaxCDN_Put() {
+func ExampleMaxCDN_put() {
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 
 	form := url.Values{}
@@ -153,7 +145,7 @@ func ExampleMaxCDN_Put() {
 	fmt.Printf("name: %s\n", data["name"].(string))
 }
 
-func ExampleMaxCDN_Delete() {
+func ExampleMaxCDN_delete() {
 	// This specific example shows how to purge a cache without using the Purge
 	// methods, more as an example of using Delete, then anything, really.
 	max := maxcdn.NewMaxCDN(alias, token, secret)
@@ -168,7 +160,7 @@ func ExampleMaxCDN_Delete() {
 	}
 }
 
-func ExampleMaxCDN_PurgeZone() {
+func ExampleMaxCDN_purgeZone() {
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 
 	rsp, err := max.PurgeZone(123456)
@@ -181,7 +173,7 @@ func ExampleMaxCDN_PurgeZone() {
 	}
 }
 
-func ExampleMaxCDN_PurgeZones() {
+func ExampleMaxCDN_purgeZones() {
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 
 	zones := []int{123456, 234567, 345678}
@@ -195,7 +187,7 @@ func ExampleMaxCDN_PurgeZones() {
 	}
 }
 
-func ExampleMaxCDN_PurgeFile() {
+func ExampleMaxCDN_purgeFile() {
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 
 	payload, err := max.PurgeFile(123456, "/master.css")
@@ -208,7 +200,7 @@ func ExampleMaxCDN_PurgeFile() {
 	}
 }
 
-func ExampleMaxCDN_PurgeFiles() {
+func ExampleMaxCDN_purgeFiles() {
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 
 	files := []string{"/master.css", "/master.js"}
@@ -222,7 +214,7 @@ func ExampleMaxCDN_PurgeFiles() {
 	}
 }
 
-func ExampleMaxCDN_Post() {
+func ExampleMaxCDN_post() {
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 
 	form := url.Values{}
@@ -242,11 +234,7 @@ func ExampleMaxCDN_Post() {
 	}
 }
 
-/****
- * Type Examples
- *******************************************************************/
-
-func ExampleResponse() {
+func Example_response() {
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 
 	var data maxcdn.Generic
@@ -254,7 +242,7 @@ func ExampleResponse() {
 	fmt.Printf("%+v\n", response)
 }
 
-func ExampleGeneric() {
+func Example_generic() {
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 
 	var data maxcdn.Generic
@@ -266,7 +254,7 @@ func ExampleGeneric() {
 	}
 }
 
-func ExampleAccount() {
+func Example_account() {
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 
 	var data maxcdn.Generic
@@ -275,7 +263,7 @@ func ExampleAccount() {
 	}
 }
 
-func ExampleAccountAddress() {
+func Example_accountAddress() {
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 
 	var data maxcdn.Generic
@@ -284,7 +272,7 @@ func ExampleAccountAddress() {
 	}
 }
 
-func ExamplePopularFiles() {
+func Example_popularFiles() {
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 
 	var data maxcdn.Generic
@@ -292,7 +280,7 @@ func ExamplePopularFiles() {
 		for i, file := range data {
 			uri := file.(map[string]interface{})["uri"].(string)
 			hit := file.(map[string]interface{})["hit"].(string)
-			fmt.Printf("%2d: %30s=%s, \n", i, uri, hit)
+			fmt.Printf("%2s: %30s=%s, \n", i, uri, hit)
 		}
 	}
 	fmt.Println("----")
@@ -300,7 +288,7 @@ func ExamplePopularFiles() {
 	fmt.Printf("    %30s=%s, \n", "summary", summaryHit)
 }
 
-func ExampleStatsSummary() {
+func Example_statsSummary() {
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 
 	var data maxcdn.Generic
@@ -309,7 +297,7 @@ func ExampleStatsSummary() {
 	}
 }
 
-func ExampleStats() {
+func Example_stats() {
 	max := maxcdn.NewMaxCDN(alias, token, secret)
 
 	var data maxcdn.Generic
@@ -318,17 +306,16 @@ func ExampleStats() {
 	}
 }
 
-/****
- * These "Functional" examples are meant to be functional integration tests.
- * To run these as integration tests export your ALIAS, TOKEN and SECRET
- * to your envioronment before running 'go test', otherwise the http
- * request will be stubbed using the json files in './_fixtures/*.json'.
- *
- * Run like:
- *
- * $ ALIAS=your_alias TOKEN=your_token SECRET=your_secret make test
- *******************************************************************/
-func Example_Functional() {
+// These "Functional" examples are meant to be functional integration tests.
+// To run these as integration tests export your ALIAS, TOKEN and SECRET
+// to your envioronment before running 'go test', otherwise the http
+// request will be stubbed using the json files in './_fixtures/*.json'.
+
+// Run like:
+
+// $ ALIAS=your_alias TOKEN=your_token SECRET=your_secret make test
+
+func Example_functional() {
 	var form url.Values
 
 	name := stringFromTimestamp()

--- a/maxcdn.go
+++ b/maxcdn.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
+	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/garyburd/go-oauth/oauth"
 )
@@ -62,20 +63,18 @@ func (max *MaxCDN) Get(endpointType interface{}, endpoint string, form url.Value
 // the json format of other endpoints.
 func (max *MaxCDN) GetLogs(form url.Values) (Logs, error) {
 	var logs Logs
+
 	rsp, err := max.Request("GET", logsPath, form)
-	defer rsp.Body.Close()
 	if err != nil {
 		return logs, err
 	}
 
-	var raw []byte
-	raw, err = ioutil.ReadAll(rsp.Body)
+	err = json.NewDecoder(rsp.Body).Decode(&logs)
+	_ = rsp.Body.Close()
 	if err != nil {
 		return logs, err
 	}
-
-	err = json.Unmarshal(raw, &logs)
-	return logs, err
+	return logs, nil
 }
 
 // Post does an OAuth signed http.Post
@@ -106,11 +105,14 @@ func (max *MaxCDN) PurgeZoneString(zone string) (*Response, error) {
 }
 
 // PurgeZonesString purges multiple zones caches.
-func (max *MaxCDN) PurgeZonesString(zones []string) (resps []*Response, last error) {
-	var resChannel = make(chan *Response)
-	var errChannel = make(chan error)
+func (max *MaxCDN) PurgeZonesString(zones []string) ([]*Response, error) {
+	var (
+		resChannel = make(chan *Response)
+		errChannel = make(chan error)
+		resps      = []*Response{}
+		last       error
+	)
 
-	mutex := sync.Mutex{}
 	for _, zone := range zones {
 		go func(zone string) {
 			res, err := max.PurgeZoneString(zone)
@@ -121,26 +123,24 @@ func (max *MaxCDN) PurgeZonesString(zones []string) (resps []*Response, last err
 
 	// Wait for all responses to come back.
 	// TODO: Consider adding some method of timing out.
-	for _ = range zones {
+	for range zones {
 		res := <-resChannel
 		err := <-errChannel
 
-		// I think the mutex might be overkill here, but I'm being
-		// safe.
-		mutex.Lock()
 		resps = append(resps, res)
 		last = err
-		mutex.Unlock()
 	}
-	return
+	close(resChannel)
+	close(errChannel)
+	return resps, last
 }
 
 // PurgeZones purges multiple zones caches.
-func (max *MaxCDN) PurgeZones(zones []int) (resps []*Response, last error) {
-	zoneStrings := make([]string, len(zones))
+func (max *MaxCDN) PurgeZones(zones []int) ([]*Response, error) {
+	zoneStrings := make([]string, 0, len(zones))
 
-	for i, zone := range zones {
-		zoneStrings[i] = fmt.Sprintf("%d", zone)
+	for _, zone := range zones {
+		zoneStrings = append(zoneStrings, strconv.FormatInt(int64(zone), 10))
 	}
 
 	return max.PurgeZonesString(zoneStrings)
@@ -148,23 +148,26 @@ func (max *MaxCDN) PurgeZones(zones []int) (resps []*Response, last error) {
 
 // PurgeFile purges a specified file by zone from cache.
 func (max *MaxCDN) PurgeFile(zone int, file string) (*Response, error) {
-	return max.PurgeFileString(fmt.Sprintf("%d", zone), file)
+	return max.PurgeFileString(strconv.FormatInt(int64(zone), 10), file)
 }
 
-// PurgeFile purges a specified file by zone from cache.
+// PurgeFileString purges a specified file by zone from cache.
 func (max *MaxCDN) PurgeFileString(zone string, file string) (*Response, error) {
 	form := url.Values{}
 	form.Set("file", file)
 
-	return max.Delete(fmt.Sprintf("/zones/pull.json/%s/cache", zone), form)
+	return max.Delete("/zones/pull.json/"+zone+"/cache", form)
 }
 
 // PurgeFiles purges multiple files from a zone.
-func (max *MaxCDN) PurgeFiles(zone int, files []string) (resps []*Response, last error) {
-	var resChannel = make(chan *Response)
-	var errChannel = make(chan error)
+func (max *MaxCDN) PurgeFiles(zone int, files []string) ([]*Response, error) {
+	var (
+		resChannel = make(chan *Response)
+		errChannel = make(chan error)
+		resps      = []*Response{}
+		last       error
+	)
 
-	mutex := sync.Mutex{}
 	for _, file := range files {
 		go func(file string) {
 			res, err := max.PurgeFile(zone, file)
@@ -176,61 +179,55 @@ func (max *MaxCDN) PurgeFiles(zone int, files []string) (resps []*Response, last
 
 	// Wait for all responses to come back.
 	// TODO: Consider adding some method of timing out.
-	for _ = range files {
+	for range files {
 		res := <-resChannel
 		err := <-errChannel
 
-		// I think the mutex might be overkill here, but I'm being
-		// safe.
-		mutex.Lock()
 		resps = append(resps, res)
 		last = err
-		mutex.Unlock()
 	}
-	return
+	close(resChannel)
+	close(errChannel)
+	return resps, last
 }
 
-func (max *MaxCDN) DoParse(endpointType interface{}, method, endpoint string, form url.Values) (rsp *Response, err error) {
-	rsp, err = max.Do(method, endpoint, form)
+// DoParse execute the http query and unmarshal the data into `endpointType`.
+func (max *MaxCDN) DoParse(endpointType interface{}, method, endpoint string, form url.Values) (*Response, error) {
+	rsp, err := max.Do(method, endpoint, form)
 	if err != nil {
-		return
+		return nil, err
 	}
-	err = json.Unmarshal(rsp.Data, &endpointType)
-	return
+	if err := json.Unmarshal(rsp.Data, &endpointType); err != nil {
+		return nil, err
+	}
+	return rsp, nil
 }
 
 // Do is a low level method to interact with MaxCDN's RESTful API via Request
 // and return a parsed Response. It's used by all other methods.
 //
 // This method closes the raw http.Response body.
-func (max *MaxCDN) Do(method, endpoint string, form url.Values) (rsp *Response, err error) {
-	rsp = new(Response)
+func (max *MaxCDN) Do(method, endpoint string, form url.Values) (*Response, error) {
+	rsp := &Response{}
+
 	res, err := max.Request(method, endpoint, form)
-	defer res.Body.Close()
-
 	if err != nil {
-		return
+		return nil, err
 	}
 
-	headers := res.Header
-	rsp.Headers = &headers
+	rsp.Headers = res.Header
 
-	var raw []byte
-	raw, err = ioutil.ReadAll(res.Body)
+	err = json.NewDecoder(res.Body).Decode(&rsp)
+	_ = res.Body.Close()
 	if err != nil {
-		return
-	}
-
-	err = json.Unmarshal(raw, &rsp)
-	if err != nil {
-		return
+		return nil, err
 	}
 
 	if rsp.Code > 299 {
-		return rsp, fmt.Errorf("%s: %s", rsp.Error.Type, rsp.Error.Message)
+		return nil, fmt.Errorf("%s: %s", rsp.Error.Type, rsp.Error.Message)
 	}
 
-	return
+	return rsp, nil
 }
 
 // Request is a low level method to interact with MaxCDN's RESTful API. It's
@@ -238,12 +235,10 @@ func (max *MaxCDN) Do(method, endpoint string, form url.Values) (rsp *Response, 
 //
 // If using this method, you must manually close the res.Body or bad things
 // may happen.
-func (max *MaxCDN) Request(method, endpoint string, form url.Values) (res *http.Response, err error) {
-	var req *http.Request
-
-	req, err = http.NewRequest(method, max.url(endpoint), nil)
+func (max *MaxCDN) Request(method, endpoint string, form url.Values) (*http.Response, error) {
+	req, err := http.NewRequest(method, max.url(endpoint), nil)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	if method == "GET" && req.URL.RawQuery != "" {
@@ -268,21 +263,23 @@ func (max *MaxCDN) Request(method, endpoint string, form url.Values) (res *http.
 	req.Header.Set("User-Agent", userAgent)
 
 	if max.Verbose {
-		if j, e := json.MarshalIndent(req, "", "  "); e == nil {
-			fmt.Printf("Request: %s\n---\n\n", j)
+		if buf, err := httputil.DumpRequest(req, true); err == nil {
+			fmt.Printf("Request: %s\n---\n\n", buf)
 		}
 	}
 
-	res, err = max.HTTPClient.Do(req)
+	res, err := max.HTTPClient.Do(req)
 	if max.Verbose {
-		if j, e := json.MarshalIndent(res, "", "  "); e == nil {
-			fmt.Printf("Response: %s\n---\n\n", j)
+		if buf, err := httputil.DumpResponse(res, true); err == nil {
+			fmt.Printf("Response: %s\n---\n\n", buf)
 		}
 	}
-	return
+	return res, err
 }
 
 func (max *MaxCDN) url(endpoint string) string {
-	endpoint = strings.TrimPrefix(endpoint, "/")
+	if len(endpoint) > 0 && endpoint[0] == '/' {
+		endpoint = endpoint[1:]
+	}
 	return fmt.Sprintf("%s/%s/%s", APIHost, max.Alias, endpoint)
 }

--- a/maxcdn_test.go
+++ b/maxcdn_test.go
@@ -33,7 +33,6 @@ func TestMaxCDN_Get(T *testing.T) {
 	// check response
 	Go(T).RefuteNil(rsp)
 	Go(T).RefuteNil(rsp.Data)
-	Go(T).RefuteNil(rsp.Headers)
 
 	// check account
 	Go(T).AssertEqual(data["account"].(map[string]interface{})["name"].(string), "MaxCDN sampleCode")
@@ -97,7 +96,6 @@ func TestMaxCDN_Put(T *testing.T) {
 	// check response
 	Go(T).RefuteNil(rsp)
 	Go(T).RefuteNil(rsp.Data)
-	Go(T).RefuteNil(rsp.Headers)
 
 	// check account
 	Go(T).AssertEqual(data["account"].(map[string]interface{})["name"].(string), "MaxCDN sampleCode")
@@ -132,7 +130,6 @@ func TestMaxCDN_Post(T *testing.T) {
 	// check response
 	Go(T).RefuteNil(rsp)
 	Go(T).RefuteNil(rsp.Data)
-	Go(T).RefuteNil(rsp.Headers)
 
 	Go(T).AssertEqual(recorder.Request.Method, "POST")
 	Go(T).AssertEqual(recorder.Request.URL.Path, "/alias/zones/pull.json")
@@ -156,7 +153,6 @@ func TestMaxCDN_Delete(T *testing.T) {
 	Go(T).AssertNil(err)
 	Go(T).RefuteNil(rsp)
 	Go(T).RefuteNil(rsp.Code)
-	Go(T).RefuteNil(rsp.Headers)
 
 	Go(T).AssertEqual(recorder.Request.Method, "DELETE")
 	Go(T).AssertEqual(recorder.Request.URL.Path, "/alias/zones/pull.json/123456/cache")
@@ -178,7 +174,6 @@ func TestMaxCDN_PurgeZone(T *testing.T) {
 	Go(T).AssertNil(err)
 	Go(T).RefuteNil(rsp)
 	Go(T).RefuteNil(rsp.Code)
-	Go(T).RefuteNil(rsp.Headers)
 
 	Go(T).AssertEqual(recorder.Request.Method, "DELETE")
 	Go(T).AssertEqual(recorder.Request.URL.Path, "/alias/zones/pull.json/123456/cache")
@@ -238,7 +233,6 @@ func TestMaxCDN_PurgeFile(T *testing.T) {
 	Go(T).AssertNil(err)
 	Go(T).RefuteNil(rsp)
 	Go(T).RefuteNil(rsp.Code)
-	Go(T).RefuteNil(rsp.Headers)
 
 	Go(T).AssertEqual(recorder.Request.Method, "DELETE")
 	Go(T).AssertEqual(recorder.Request.URL.Path, "/alias/zones/pull.json/123456/cache")
@@ -262,7 +256,6 @@ func TestMaxCDN_PurgeFileString(T *testing.T) {
 	Go(T).AssertNil(err)
 	Go(T).RefuteNil(rsp)
 	Go(T).RefuteNil(rsp.Code)
-	Go(T).RefuteNil(rsp.Headers)
 
 	Go(T).AssertEqual(recorder.Request.Method, "DELETE")
 	Go(T).AssertEqual(recorder.Request.URL.Path, "/alias/zones/pull.json/123456/cache")

--- a/types.go
+++ b/types.go
@@ -5,53 +5,64 @@ import (
 	"net/http"
 )
 
+// Error represent a maxcnd error.
+type Error struct {
+	Message string `json:"message,omitempty"`
+	Type    string `json:"type,omitempty"`
+}
+
+// Error implements go's error interface.
+func (e Error) Error() string {
+	return e.Type + ": " + e.Message
+}
+
 // Response object for all json requests.
 type Response struct {
 	Code  int             `json:"code,omitempty"`
 	Data  json.RawMessage `json:"data,omitempty"`
-	Error struct {
-		Message string `json:"message,omitempty"`
-		Type    string `json:"type,omitempty"`
-	} `json:"error,omitempty"`
+	Error Error           `json:"error,omitempty"`
 
 	// Non-JSON data.
-	Headers *http.Header
+	Headers http.Header `json:"-"`
 }
 
 // Generic is the generic data type for JSON responses from API calls.
 type Generic map[string]interface{}
 
-// Logs
+// LogRecord holds the data of a single record.
+type LogRecord struct {
+	Bytes           int     `json:"bytes"`
+	CacheStatus     string  `json:"cache_status"`
+	ClientAsn       string  `json:"client_asn"`
+	ClientCity      string  `json:"client_city"`
+	ClientContinent string  `json:"client_continent"`
+	ClientCountry   string  `json:"client_country"`
+	ClientDma       string  `json:"client_dma"`
+	ClientIP        string  `json:"client_ip"`
+	ClientLatitude  float64 `json:"client_latitude"`
+	ClientLongitude float64 `json:"client_longitude"`
+	ClientState     string  `json:"client_state"`
+	CompanyID       int     `json:"company_id"`
+	Hostname        string  `json:"hostname"`
+	Method          string  `json:"method"`
+	OriginTime      float64 `json:"origin_time"`
+	Pop             string  `json:"pop"`
+	Protocol        string  `json:"protocol"`
+	QueryString     string  `json:"query_string"`
+	Referer         string  `json:"referer"`
+	Scheme          string  `json:"scheme"`
+	Status          int     `json:"status"`
+	Time            string  `json:"time"`
+	URI             string  `json:"uri"`
+	UserAgent       string  `json:"user_agent"`
+	ZoneID          int     `json:"zone_id"`
+}
+
+// Logs .
 type Logs struct {
-	Limit       int    `json:"limit"`
-	NextPageKey string `json:"next_page_key"`
-	Page        int    `json:"page"`
-	Records     []struct {
-		Bytes           int     `json:"bytes"`
-		CacheStatus     string  `json:"cache_status"`
-		ClientAsn       string  `json:"client_asn"`
-		ClientCity      string  `json:"client_city"`
-		ClientContinent string  `json:"client_continent"`
-		ClientCountry   string  `json:"client_country"`
-		ClientDma       string  `json:"client_dma"`
-		ClientIp        string  `json:"client_ip"`
-		ClientLatitude  float64 `json:"client_latitude"`
-		ClientLongitude float64 `json:"client_longitude"`
-		ClientState     string  `json:"client_state"`
-		CompanyID       int     `json:"company_id"`
-		Hostname        string  `json:"hostname"`
-		Method          string  `json:"method"`
-		OriginTime      float64 `json:"origin_time"`
-		Pop             string  `json:"pop"`
-		Protocol        string  `json:"protocol"`
-		QueryString     string  `json:"query_string"`
-		Referer         string  `json:"referer"`
-		Scheme          string  `json:"scheme"`
-		Status          int     `json:"status"`
-		Time            string  `json:"time"`
-		Uri             string  `json:"uri"`
-		UserAgent       string  `json:"user_agent"`
-		ZoneID          int     `json:"zone_id"`
-	} `json:"records"`
-	RequestTime int `json:"request_time"`
+	Limit       int         `json:"limit"`
+	NextPageKey string      `json:"next_page_key"`
+	Page        int         `json:"page"`
+	Records     []LogRecord `json:"records"`
+	RequestTime int         `json:"request_time"`
 }


### PR DESCRIPTION
Minor cleanup including:

- Add all example to godoc (rename example function)
- Discard travis tests for go < 1.4
- Use .PHONY rule in makefile
- comply to golint
- Use "standalone" structs instead of nested for easier testing
- Remove pointer on header because it is already a reference
- use http.Dump{Request,Response} instead of json.MarshalIndent
- remove unnecessary named returns
- remove unnecessary mutexes
- close channels when finished
- minor optimizations
- Add .gitignore